### PR TITLE
修复多个字体名在同一字体文件的异常

### DIFF
--- a/AssFontSubset/MainWindow.xaml.cs
+++ b/AssFontSubset/MainWindow.xaml.cs
@@ -262,7 +262,7 @@ namespace AssFontSubset
                 }
 
                 int index = 0;
-                var fontNames = new List<Tuple<string, int>>(); // (fontname, index)
+                var fontNames = new HashSet<Tuple<string, int>>(); // (fontname, index)
                 bool isCollection = Path.GetExtension(file).ToLower() == ".ttc";
 
                 if (!isCollection) {
@@ -287,7 +287,7 @@ namespace AssFontSubset
             return true;
         }
 
-        private void MatchFontNames(string file, List<Tuple<string, int>> fontNames, Dictionary<string, List<AssFontInfo>> fontsInAss, int index, Dictionary<string, bool> flags) 
+        private void MatchFontNames(string file, HashSet<Tuple<string, int>> fontNames, Dictionary<string, List<AssFontInfo>> fontsInAss, int index, Dictionary<string, bool> flags) 
         {
             var familynames = new List<string>();
             var fullnames = new List<string>();
@@ -319,15 +319,11 @@ namespace AssFontSubset
                 }
             }
 
-            var fullnameResult = fullnames.Where(name => fontsInAss.ContainsKey(name));
-            if (fullnameResult.Count() > 0) {
-                fontNames.Add(new Tuple<string, int>(fullnameResult.Distinct().First(), index));
-                return;
+            foreach (var fullnameResult in familynames.Where(name => fontsInAss.ContainsKey(name))) {
+                fontNames.Add(new Tuple<string, int>(fullnameResult, index));
             }
-            var familynameResult = familynames.Where(name => fontsInAss.ContainsKey(name));
-            if (familynameResult.Count() > 0) {
-                fontNames.Add(new Tuple<string, int>(familynameResult.Distinct().First(), index));
-                return;
+            foreach (var familynameResult in familynames.Where(name => fontsInAss.ContainsKey(name))) {
+                fontNames.Add(new Tuple<string, int>(familynameResult, index));
             }
         }
 


### PR DESCRIPTION
try to fix #3 

现在看起来是把每个字体名认作不同的字体，也许有更优雅的解决方式？

不懂 C#，乱写的。

request review.