### PR TITLE
Bugfix: Fontname in vertical styles

### DIFF
--- a/.github/workflows/afs-cmd-ci.yml
+++ b/.github/workflows/afs-cmd-ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     - name: Setup Zig Compiler (target linux)
       if: matrix.config.target == 'linux-musl'
-      uses: mlugg/setup-zig@v1
+      uses: mlugg/setup-zig@v2.2.1
       with:
         version: "master"
 

--- a/AssFontSubset.Core/src/SubsetCore.cs
+++ b/AssFontSubset.Core/src/SubsetCore.cs
@@ -236,9 +236,20 @@ public class SubsetCore(ILogger? logger = null)
         
         foreach (var style in ass.Styles.Collection)
         {
-            if (assFontNameMap.TryGetValue(style.Fontname, out var newFn))
+            if (style.Fontname.StartsWith('@'))
             {
-                style.Fontname = newFn;
+                if (assFontNameMap.TryGetValue(style.Fontname[1..], out var newFn))
+                {
+                    style.Fontname = '@' + newFn;
+                }
+            }
+            else
+            {
+                if (assFontNameMap.TryGetValue(style.Fontname, out var newFn))
+                {
+                    style.Fontname = newFn;
+                }
+
             }
         }
         

--- a/AssFontSubset.Core/src/SubsetCore.cs
+++ b/AssFontSubset.Core/src/SubsetCore.cs
@@ -249,7 +249,6 @@ public class SubsetCore(ILogger? logger = null)
                 {
                     style.Fontname = newFn;
                 }
-
             }
         }
         


### PR DESCRIPTION
Bug: `@`-prefixed `Fontname` in styles(i.e. vertical styles) will not be replaced after subsetting.
For instance:
```
[Script Info]
...
[V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
...
Style: Default - roll -1,@云书法手书建刚槐树简,78,&H00FFFFFF,&H000000FF,&H00000000,&H00E4E0B5,0,0,0,0,100,100,0,0,1,3.9,0,1,60,60,10,0
...
```
becomes
```
[Script Info]
...
; Font Subset: OS9J8DAO - 云书法手书建刚槐树简
...
[V4+ Styles]
Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
...
Style: Default - roll -1,@云书法手书建刚槐树简,78,&H00FFFFFF,&H000000FF,&H00000000,&H00E4E0B5,0,0,0,0,100,100,0,0,1,3.9,0,1,60,60,10,0
...
```
The update ensures that font name mappings are correctly applied to both regular and '@'-prefixed font names in ASS styles.